### PR TITLE
Let's not set :title inside a partial

### DIFF
--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,5 +1,3 @@
-<% content_for :title, message.subject %>
-
 <div class="message" id="<%= dom_id message %>">
   <ul class="headers">
     <li>From: <%= message.from %></li>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, @message.subject %>
+
 <p style="color: green"><%= notice %></p>
 
 <%= render @message %>


### PR DESCRIPTION
Current code calls `content_for :title` inside a partial template, but that's something that generally should better not be done in partials, since partials can be repeatedly called from index action (which is something that I'm planning to implement later).