### PR TITLE
Fix regexp in without_list_prefix helper to match shorter

### DIFF
--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,6 +1,6 @@
 module MessagesHelper
     def without_list_prefix(subject)
-        subject.sub(/^\[.+\]\s*/, '')
+        subject.sub(/^\[.+?\]\s*/, '')
     end
 
     MARGIN = 50


### PR DESCRIPTION
While the helper just aims to remove heading `[ruby-dev:1] ` from the given string, it actually removes everything until the last "]" in the given string. This patch fixes it.

```
before:
without_list_prefix("[ruby-dev:1] Re: [ruby-list:3486] Re: eval with dynamic binding [Re: meta programming features]")
 #=> ""

after:
without_list_prefix("[ruby-dev:1] Re: [ruby-list:3486] Re: eval with dynamic binding [Re: meta programming features]")
 #=> "Re: [ruby-list:3486] Re: eval with dynamic binding [Re: meta programming features]"
```