### PR TITLE
Cleaning up messages#show action

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,14 +12,10 @@ class MessagesController < ApplicationController
     render :search
   end
 
-  # GET /messages/1
+  # GET /messages/ruby-dev/1
   def show
-    if params[:id]
-      @message = Message.find(params[:id])
-    else
-      list = List.find_by_name(params[:list_name])
-      @message = Message.find_by(list_id: list.id, list_seq: params[:list_seq])
-    end
+    list = List.find_by_name(params[:list_name])
+    @message = Message.find_by(list_id: list.id, list_seq: params[:list_seq])
   end
 
   private


### PR DESCRIPTION
messages#show implements two params patterns, one is `:id`, the other is `:list_name` and `:list_seq`, but indeed the former is not routed in the [current routes.rb](https://github.com/ruby/blade.ruby-lang.org/blob/39ae0abf7bfbf395273ef9401a387840a6c1ec6c/config/routes.rb#L3).

So let's get rid of the dead code that processes `params[:id]` from the show action and make the code simple.