### PR TITLE
Guard Rails generated migration file from the cop rant

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,10 @@
+AllCops:
+  Exclude:
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+    - 'coverage/**/*'
+    - 'db/migrate/20251010175058_add_service_name_to_active_storage_blobs.active_storage.rb'
+
 Style:
   Enabled: false
 


### PR DESCRIPTION
We're seeing a Rubocop offense against Rails' generated active_storage migration file. This patch silences that noise.