### PR TITLE
add_message_id_header_and_parent_id_to_message

### DIFF
--- a/db/migrate/20251010153708_add_message_id_header_and_parent_id_to_message.rb
+++ b/db/migrate/20251010153708_add_message_id_header_and_parent_id_to_message.rb
@@ -1,0 +1,6 @@
+class AddMessageIdHeaderAndParentIdToMessage < ActiveRecord::Migration[7.1]
+  def change
+    add_column :messages, :message_id_header, :string
+    add_column :messages, :parent_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_10_175060) do
     t.integer "list_id"
     t.integer "list_seq"
     t.timestamptz "published_at"
+    t.string "message_id_header"
+    t.integer "parent_id"
     t.index ["body"], name: "index_messages_on_body", opclass: :gin_trgm_ops, using: :gin
     t.index ["list_id", "list_seq"], name: "index_messages_on_list_id_and_list_seq", unique: true
   end


### PR DESCRIPTION
Here's an AR migration that adds two columns to messages table:

- message_id_header: the `message-id` SMTP header. Suffixed `_header` so that the column name doesn't look like an FK to another message
- parent_id: reference to another message, used for drawing the mail thread tree. Will be computed from `in-reply-to` and `references` SMTP headers