### PR TITLE
No need to switch search SQL between Rails envs

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -39,12 +39,7 @@ class MessagesController < ApplicationController
 
     # %> and <-> are defined by pg_trgm.
     # https://www.postgresql.org/docs/17/pgtrgm.html
-    message_where = if Rails.env.production?
-                      Message.where('body %> ? AND list_id IN (?)', query, list_ids)
-                        .order(Arel.sql('body <-> ?', query))
-    else
-      Message.where('body LIKE ? AND list_id IN (?)', "%#{query}%", list_ids)
-    end
+    message_where = Message.where('body %> ? AND list_id IN (?)', query, list_ids).order(Arel.sql('body <-> ?', query))
     @messages = message_where.offset(page * PER_PAGE).limit(PER_PAGE)
   end
 end


### PR DESCRIPTION
We do no longer need to switch SQLs between Rails envs, because we're connecting to Postgres everywhere since #49.