### PR TITLE
Yet another email importer that imports from raw mail text

### DIFF
--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,6 +1,6 @@
 module MessagesHelper
   def without_list_prefix(subject)
-    subject.sub(/^\[.+?\]\s*/, '')
+    subject&.sub(/^\[.+?\]\s*/, '')
   end
 
   MARGIN = 50

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -12,7 +12,12 @@ class Message < ApplicationRecord
 
   class << self
     def from_mail(mail, list, list_seq)
-      body = mail.body.decoded.encode Encoding::UTF_8, Encoding::ISO_2022_JP
+      body = begin
+        mail.body.decoded.encode Encoding::UTF_8, Encoding::ISO_2022_JP
+      rescue Encoding::InvalidByteSequenceError
+        mail.body.decoded.encode Encoding::UTF_8, Encoding::ISO_2022_JP, invalid: :replace, undef: :replace
+      end
+
       from = mail.from_address.decoded
       new list_id: list.id, list_seq: list_seq, body: body, subject: mail.subject, from: from, published_at: mail.date, message_id_header: mail.message_id
     end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -16,6 +16,8 @@ class Message < ApplicationRecord
         mail.body.decoded.encode Encoding::UTF_8, Encoding::ISO_2022_JP
       rescue Encoding::InvalidByteSequenceError
         mail.body.decoded.encode Encoding::UTF_8, Encoding::ISO_2022_JP, invalid: :replace, undef: :replace
+      rescue Encoding::UndefinedConversionError
+        mail.decoded
       end
 
       from = mail.from_address.decoded

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -16,7 +16,8 @@ class Message < ApplicationRecord
       if ((list.name == 'ruby-dev') && list_seq.in?([13859, 26229, 39731, 39734])) || ((list.name == 'ruby-core') && list_seq.in?([5231])) || ((list.name == 'ruby-list') && list_seq.in?([29637, 29711, 30148])) || ((list.name == 'ruby-talk') && list_seq.in?([5198, 61316]))
         body.gsub!("\u0000", '')
       end
-      subject = Kconv.toutf8 mail.subject
+      subject = mail.subject
+      subject = Kconv.toutf8 subject if subject
       from = mail.from_address&.decoded
       if !from && (list.name == 'ruby-core') && (list_seq == 161)
         from = mail.from.encode Encoding::UTF_8, Encoding::KOI8_R

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -16,6 +16,9 @@ class Message < ApplicationRecord
       if ((list.name == 'ruby-dev') && list_seq.in?([13859, 26229, 39731, 39734])) || ((list.name == 'ruby-core') && list_seq.in?([5231])) || ((list.name == 'ruby-list') && list_seq.in?([29637, 29711, 30148])) || ((list.name == 'ruby-talk') && list_seq.in?([5198, 61316]))
         body.gsub!("\u0000", '')
       end
+      if (list.name == 'ruby-list') && list_seq.in?([37565, 38116, 43106])
+        mail.header[:subject].value.chop!
+      end
       subject = mail.subject
       subject = Kconv.toutf8 subject if subject
       from = Kconv.toutf8 mail.from_address&.raw

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -29,6 +29,8 @@ class Message < ApplicationRecord
         from = mail.from.encode Encoding::UTF_8, Encoding::KOI8_R
       end
 
+      message_id = mail.message_id.encode Encoding::UTF_8, invalid: :replace, undef: :replace
+
       # mail.in_reply_to returns strange Array object in some cases (?), so let's use the raw value
       parent_message_id = extract_message_id_from_in_reply_to(mail.header[:in_reply_to]&.value)
       parent_message = Message.find_by message_id_header: parent_message_id if parent_message_id
@@ -41,7 +43,7 @@ class Message < ApplicationRecord
         end
       end
 
-      new list_id: list.id, list_seq: list_seq, body: body, subject: subject, from: from, published_at: mail.date, message_id_header: mail.message_id, parent_id: parent_message&.id
+      new list_id: list.id, list_seq: list_seq, body: body, subject: subject, from: from, published_at: mail.date, message_id_header: message_id, parent_id: parent_message&.id
     end
 
     private def extract_message_id_from_in_reply_to(header)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -13,7 +13,7 @@ class Message < ApplicationRecord
   class << self
     def from_mail(mail, list, list_seq)
       body = Kconv.toutf8 mail.body.raw_source
-      if (list.name == 'ruby-dev') && (list_seq == 13859)
+      if ((list.name == 'ruby-dev') && list_seq.in?([13859, 26229, 39731, 39734])) || ((list.name == 'ruby-core') && list_seq.in?([5231])) || ((list.name == 'ruby-list') && list_seq.in?([29637, 29711, 30148])) || ((list.name == 'ruby-talk') && list_seq.in?([5198, 61316]))
         body.gsub!("\u0000", '')
       end
       subject = Kconv.toutf8 mail.subject

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -18,7 +18,7 @@ class Message < ApplicationRecord
       end
       subject = mail.subject
       subject = Kconv.toutf8 subject if subject
-      from = Kconv.toutf8 mail.from_address.raw
+      from = Kconv.toutf8 mail.from_address&.raw
       if !from && (list.name == 'ruby-core') && (list_seq == 161)
         from = mail.from.encode Encoding::UTF_8, Encoding::KOI8_R
       end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -13,7 +13,8 @@ class Message < ApplicationRecord
   class << self
     def from_mail(mail, list, list_seq)
       body = mail.body.decoded.encode Encoding::UTF_8, Encoding::ISO_2022_JP
-      new list_id: list.id, list_seq: list_seq, body: body, subject: mail.subject, from: mail.from, published_at: mail.date, message_id_header: mail.message_id
+      from = mail.from_address.decoded
+      new list_id: list.id, list_seq: list_seq, body: body, subject: mail.subject, from: from, published_at: mail.date, message_id_header: mail.message_id
     end
 
     def from_s3(list_name, list_seq, s3_client = Aws::S3::Client.new(region: BLADE_BUCKET_REGION))

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -12,14 +12,7 @@ class Message < ApplicationRecord
 
   class << self
     def from_mail(mail, list, list_seq)
-      body = begin
-        mail.body.decoded.encode Encoding::UTF_8, Encoding::ISO_2022_JP
-      rescue Encoding::InvalidByteSequenceError
-        mail.body.decoded.encode Encoding::UTF_8, Encoding::ISO_2022_JP, invalid: :replace, undef: :replace
-      rescue Encoding::UndefinedConversionError
-        mail.decoded
-      end
-
+      body = Kconv.toutf8 mail.body.raw_source
       from = mail.from_address.decoded
       new list_id: list.id, list_seq: list_seq, body: body, subject: mail.subject, from: from, published_at: mail.date, message_id_header: mail.message_id
     end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -29,7 +29,7 @@ class Message < ApplicationRecord
         from = mail.from.encode Encoding::UTF_8, Encoding::KOI8_R
       end
 
-      message_id = mail.message_id.encode Encoding::UTF_8, invalid: :replace, undef: :replace
+      message_id = mail.message_id&.encode Encoding::UTF_8, invalid: :replace, undef: :replace
 
       # mail.in_reply_to returns strange Array object in some cases (?), so let's use the raw value
       parent_message_id = extract_message_id_from_in_reply_to(mail.header[:in_reply_to]&.value)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -12,7 +12,8 @@ class Message < ApplicationRecord
 
   class << self
     def from_mail(mail, list, list_seq)
-      new list_id: list.id, list_seq: list_seq, body: mail.body.decoded, subject: mail.subject, from: mail.from, published_at: mail.date, message_id_header: mail.message_id
+      body = mail.body.decoded.encode Encoding::UTF_8, Encoding::ISO_2022_JP
+      new list_id: list.id, list_seq: list_seq, body: body, subject: mail.subject, from: mail.from, published_at: mail.date, message_id_header: mail.message_id
     end
 
     def from_s3(list_name, list_seq, s3_client = Aws::S3::Client.new(region: BLADE_BUCKET_REGION))

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -18,6 +18,9 @@ class Message < ApplicationRecord
       end
       subject = Kconv.toutf8 mail.subject
       from = mail.from_address&.decoded
+      if !from && (list.name == 'ruby-core') && (list_seq == 161)
+        from = mail.from.encode Encoding::UTF_8, Encoding::KOI8_R
+      end
       if (list.name == 'ruby-dev') && (list_seq == 13859)
         from = Kconv.toutf8 from
       end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -18,12 +18,9 @@ class Message < ApplicationRecord
       end
       subject = mail.subject
       subject = Kconv.toutf8 subject if subject
-      from = mail.from_address&.decoded
+      from = Kconv.toutf8 mail.from_address.raw
       if !from && (list.name == 'ruby-core') && (list_seq == 161)
         from = mail.from.encode Encoding::UTF_8, Encoding::KOI8_R
-      end
-      if (list.name == 'ruby-dev') && (list_seq == 13859)
-        from = Kconv.toutf8 from
       end
 
       # mail.in_reply_to returns strange Array object in some cases (?), so let's use the raw value

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -18,6 +18,9 @@ class Message < ApplicationRecord
       end
       subject = Kconv.toutf8 mail.subject
       from = mail.from_address.decoded
+      if (list.name == 'ruby-dev') && (list_seq == 13859)
+        from = Kconv.toutf8 from
+      end
 
       # mail.in_reply_to returns strange Array object in some cases (?), so let's use the raw value
       parent_message_id = extract_message_id_from_in_reply_to(mail.header[:in_reply_to]&.value)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -11,6 +11,10 @@ class Message < ApplicationRecord
   self.skip_time_zone_conversion_for_attributes = [:published_at]
 
   class << self
+    def from_mail(mail, list, list_seq)
+      new list_id: list.id, list_seq: list_seq, body: mail.body.decoded, subject: mail.subject, from: mail.from, published_at: mail.date, message_id_header: mail.message_id
+    end
+
     def from_s3(list_name, list_seq, s3_client = Aws::S3::Client.new(region: BLADE_BUCKET_REGION))
       obj = s3_client.get_object(bucket: BLADE_BUCKET_NAME, key: "#{list_name}/#{list_seq}")
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -13,6 +13,9 @@ class Message < ApplicationRecord
   class << self
     def from_mail(mail, list, list_seq)
       body = Kconv.toutf8 mail.body.raw_source
+      if (list.name == 'ruby-dev') && (list_seq == 13859)
+        body.gsub!("\u0000", '')
+      end
       subject = Kconv.toutf8 mail.subject
       from = mail.from_address.decoded
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -19,6 +19,9 @@ class Message < ApplicationRecord
       if (list.name == 'ruby-list') && list_seq.in?([37565, 38116, 43106])
         mail.header[:subject].value.chop!
       end
+      if (list.name == 'ruby-list') && (list_seq.in?([41850, 43710]))
+        mail.header[:subject].value = Kconv.toutf8 mail.header[:subject].value
+      end
       subject = mail.subject
       subject = Kconv.toutf8 subject if subject
       from = Kconv.toutf8 mail.from_address&.raw

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -17,7 +17,7 @@ class Message < ApplicationRecord
         body.gsub!("\u0000", '')
       end
       subject = Kconv.toutf8 mail.subject
-      from = mail.from_address.decoded
+      from = mail.from_address&.decoded
       if (list.name == 'ruby-dev') && (list_seq == 13859)
         from = Kconv.toutf8 from
       end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -13,8 +13,9 @@ class Message < ApplicationRecord
   class << self
     def from_mail(mail, list, list_seq)
       body = Kconv.toutf8 mail.body.raw_source
+      subject = Kconv.toutf8 mail.subject
       from = mail.from_address.decoded
-      new list_id: list.id, list_seq: list_seq, body: body, subject: mail.subject, from: from, published_at: mail.date, message_id_header: mail.message_id
+      new list_id: list.id, list_seq: list_seq, body: body, subject: subject, from: from, published_at: mail.date, message_id_header: mail.message_id
     end
 
     def from_s3(list_name, list_seq, s3_client = Aws::S3::Client.new(region: BLADE_BUCKET_REGION))

--- a/bin/import_mails
+++ b/bin/import_mails
@@ -16,6 +16,8 @@ list = List.find_by_name(params[:list])
 
 errors = []
 
+Rails.logger.level = Logger::INFO
+
 Message.transaction do
   (params[:from]..params[:to]).each do |seq|
     begin

--- a/bin/import_mails
+++ b/bin/import_mails
@@ -14,6 +14,8 @@ end.parse!(into: params)
 
 list = List.find_by_name(params[:list])
 
+errors = []
+
 Message.transaction do
   (params[:from]..params[:to]).each do |seq|
     begin
@@ -29,7 +31,10 @@ Message.transaction do
     rescue ActiveRecord::RecordNotUnique
       STDERR.puts("#{list}:#{seq} already exists in Postgres")
     rescue StandardError => e
+      errors << [seq, e]
       STDERR.puts("failed to import #{list}:#{seq}: #{e}")
     end
   end
 end
+
+pp errors if errors.any?

--- a/bin/import_mails
+++ b/bin/import_mails
@@ -17,7 +17,12 @@ list = List.find_by_name(params[:list])
 Message.transaction do
   (params[:from]..params[:to]).each do |seq|
     begin
-      str = File.binread BASE_DIR.join(list.name, seq.to_s)
+      filepath = BASE_DIR.join(list.name, seq.to_s)
+      next unless filepath.exist?
+
+      str = File.binread filepath
+      next if str.blank?
+
       mail = Mail.read_from_string str
       message = Message.from_mail mail, list, seq
       message.save!

--- a/bin/import_mails
+++ b/bin/import_mails
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'mail'
+
+BASE_DIR = Rails.root.join('tmp')
+
+params = {}
+OptionParser.new do |opts|
+  opts.on('--list LIST')
+  opts.on('--from FROM', Integer)
+  opts.on('--to TO', Integer)
+end.parse!(into: params)
+
+list = List.find_by_name(params[:list])
+
+Message.transaction do
+  (params[:from]..params[:to]).each do |seq|
+    begin
+      str = File.binread BASE_DIR.join(list.name, seq.to_s)
+      mail = Mail.read_from_string str
+      message = Message.new list_id: list.id, list_seq: seq, body: mail.body.decoded, subject: mail.subject, from: mail.from, published_at: mail.date, message_id_header: mail.message_id
+      message.save!
+    rescue ActiveRecord::RecordNotUnique
+      STDERR.puts("#{list}:#{seq} already exists in Postgres")
+    rescue StandardError => e
+      STDERR.puts("failed to import #{list}:#{seq}: #{e}")
+    end
+  end
+end

--- a/bin/import_mails
+++ b/bin/import_mails
@@ -19,7 +19,7 @@ Message.transaction do
     begin
       str = File.binread BASE_DIR.join(list.name, seq.to_s)
       mail = Mail.read_from_string str
-      message = Message.new list_id: list.id, list_seq: seq, body: mail.body.decoded, subject: mail.subject, from: mail.from, published_at: mail.date, message_id_header: mail.message_id
+      message = Message.from_mail mail, list, seq
       message.save!
     rescue ActiveRecord::RecordNotUnique
       STDERR.puts("#{list}:#{seq} already exists in Postgres")

--- a/db/migrate/20251017161507_add_index_messages_message_id_header.rb
+++ b/db/migrate/20251017161507_add_index_messages_message_id_header.rb
@@ -1,0 +1,4 @@
+class AddIndexMessagesMessageIdHeader < ActiveRecord::Migration[8.0]
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_10_175060) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_17_161507) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -9,9 +9,8 @@ Date: 2005-12-15T19:32:40+09:00
 
 Hello, world!
 END_OF_BODY
-
     m = Message.from_mail(mail, List.find_by_name('ruby-list'), 1)
-    assert_equal "Hello, world!\n", m.body
+    assert_equal "Hello, world!\r\n", m.body
 
     assert_equal DateTime.parse('2005-12-15T19:32:40+09:00'), m.published_at
   end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,6 +1,21 @@
 require "test_helper"
 
 class MessageTest < ActiveSupport::TestCase
+  test 'from_mail' do
+    mail = Mail.read_from_string(<<END_OF_BODY)
+Subject: [ruby-list:1] Hello
+From: alice@example.com
+Date: 2005-12-15T19:32:40+09:00
+
+Hello, world!
+END_OF_BODY
+
+    m = Message.from_mail(mail, List.find_by_name('ruby-list'), 1)
+    assert_equal "Hello, world!\n", m.body
+
+    assert_equal DateTime.parse('2005-12-15T19:32:40+09:00'), m.published_at
+  end
+
   test 'from_string' do
     m = Message.from_string(<<END_OF_BODY)
 Subject: [ruby-list:1] Hello


### PR DESCRIPTION
Here's another email importer that imports emails from raw text dump instead of the converted "S3 data".

The biggest addition on this version from the previous one is that it retrieves `in-reply-to` message-ids (that are dropped in the "S3 data") so we can construct email threads.