### PR TITLE
Mask from address emails on messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem "stimulus-rails"
 
 gem 'tailwindcss-rails'
 
+gem 'active_decorator'
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_decorator (1.5.1)
+      activesupport
     activejob (8.0.3)
       activesupport (= 8.0.3)
       globalid (>= 0.3.6)
@@ -347,6 +349,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  active_decorator
   aws-sdk-s3 (~> 1)
   bootsnap
   brakeman

--- a/app/decorators/message_decorator.rb
+++ b/app/decorators/message_decorator.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module MessageDecorator
+end

--- a/app/decorators/message_decorator.rb
+++ b/app/decorators/message_decorator.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 module MessageDecorator
+  def from
+    super&.gsub(/@[a-zA-Z.\-]+/, '@...')
+  end
 end

--- a/test/decorators/message_decorator_test.rb
+++ b/test/decorators/message_decorator_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MessageDecoratorTest < ActiveSupport::TestCase
+  def setup
+    @message = Message.new.extend MessageDecorator
+  end
+
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This patch masks hostname part in mail from addresses.

I don't want to hard-sell my own gem here, but I believe this has to be the simplest solution to mask all `Message#from` occurrences on the whole website.