### PR TITLE
Decode x-gzip64 attachments

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -67,7 +67,7 @@ class Message < ApplicationRecord
         handle_body p
       end
     elsif part.attachment?
-      file = StringIO.new(part.body.raw_source)
+      file = StringIO.new(part.decoded)
       attachments.attach(io: file, filename: part.filename, content_type: part.content_type)
     else
       case part.content_type&.downcase

--- a/bin/import_mails
+++ b/bin/import_mails
@@ -2,6 +2,7 @@
 
 require 'optparse'
 require 'mail'
+require 'mail/encodings/x_gzip64'
 
 BASE_DIR = Rails.root.join('tmp')
 

--- a/lib/mail/encodings/x_gzip64.rb
+++ b/lib/mail/encodings/x_gzip64.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'mail/encodings/base64'
+require 'zlib'
+
+module Mail
+  module Encodings
+    class XGzip64 < Base64
+      NAME = 'x-gzip64'
+      PRIORITY = 3
+      Encodings.register(NAME, self)
+
+      def self.decode(str)
+        base64str = Utilities.decode_base64(str)
+        ActiveSupport::Gzip.decompress(base64str)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Attachment files have to decoded before persisted, but some attachments are encoded with x-gzip64. Here's a decoder that does the work, and now we can just call `.decoded` before saving each file.